### PR TITLE
poll file descriptors before close in spawn

### DIFF
--- a/src/posix-io.c
+++ b/src/posix-io.c
@@ -439,7 +439,7 @@ _gpgme_io_spawn (const char *path, char *const argv[], unsigned int flags,
 		}
 	      do
 	        {
-		  nonzero = poll (pfd, POLLFD_MAX, 0);
+		  nonzero = poll (pfd, max_fds < POLLFD_MAX ? max_fds : POLLFD_MAX, 0);
 		}
 	      while (nonzero <= 0 && (errno == EINTR || errno == EAGAIN));
 	      if (nonzero <= 0)


### PR DESCRIPTION
# Problem Statement
When running GPGME within Docker, the maximum number of FDs may be set higher than a sane and reasonable values for its specific use-case, causing many close calls to be issued, introducing a major slowdown in performance any calls to the `gpg` binary.

# Proposed solution
This PR attempts to mitigate the problem by calling `poll` on the entire range of file descriptors before issuing `close` calls to each file descriptor. This limits the number of close calls made to the number of active file descriptors in the current process.


This PR also includes some minor cherry-picked changes from 1.12.
